### PR TITLE
Inserting information on the go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Installation
 Dependencies:
 
 * **git 1.7.3** or newer
+* **go 1.5.3** or newer
 
 #### Homebrew
 


### PR DESCRIPTION
I was using `go version go1.2.1 linux/amd64` and I got lots of errors, like this

```
$ ./script/build -o ~/bin/hub
../go/src/github.com/github/hub/github/config_decoder.go:7:2: cannot find package "github.com/BurntSushi/toml" in any of:
    /usr/lib/go/src/pkg/github.com/BurntSushi/toml (from $GOROOT)
    /tmp/go/src/github.com/BurntSushi/toml (from $GOPATH)
```

I looked at the source and looked at the specification of libraries in the source, and kind of though that seemed right, only maybe the version of go wasn't considering it correctly. I upgraded to the current version, and voilà, it worked. Maybe it's not the oldest version that works, but it does work with this one.
